### PR TITLE
Duplicate samples option added

### DIFF
--- a/Studio One File Finder/FilePreferencesViewModel.cs
+++ b/Studio One File Finder/FilePreferencesViewModel.cs
@@ -66,6 +66,15 @@ namespace Studio_One_File_Finder
 				SetIfDiff(ref _overWriteValidPaths, value);
 			}
 		}
+		private bool _updateDuplicates;
+		public bool UpdateDuplicates
+		{
+			get => _updateDuplicates;
+			set
+			{
+				SetIfDiff(ref _updateDuplicates, value);
+			}
+		}
 
 		private bool _canSubmit;
 		public bool CanSubmit
@@ -96,6 +105,7 @@ namespace Studio_One_File_Finder
 
 			ReplaceSampleOne = true;
 			OverWriteValidPaths = false;
+			UpdateDuplicates = false;
 
 			CanSubmit = false;
 			SampleFolders = new();
@@ -145,7 +155,8 @@ namespace Studio_One_File_Finder
 			};
 			var settings = new ExtraSettings
 			{
-				OverwriteValidPaths = this.OverWriteValidPaths
+				OverwriteValidPaths = OverWriteValidPaths,
+				UpdateDuplicateFiles = UpdateDuplicates
 			};
 			_fileUpdater.UpdateFiles(validSampleDirs, validProjectDirs, extraPlugins, settings, errorHandler, outputHandler);
 		}
@@ -273,6 +284,7 @@ namespace Studio_One_File_Finder
 	public struct ExtraSettings
 	{
 		public bool OverwriteValidPaths;
+		public bool UpdateDuplicateFiles;
 		List<FileType> ExtraPlugins;
 
 	}

--- a/Studio One File Finder/FileUpdater.cs
+++ b/Studio One File Finder/FileUpdater.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO.Compression;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Xml;
 
@@ -21,6 +22,7 @@ namespace Studio_One_File_Finder
 	{
 		const int XML_WRAP_CHARACTER_COUNT = 100;
 		const string MEDIA_POOL = "Song/mediapool.xml";
+		const string BACKUP_FILE_EXTENSION = ".s1filefinderbackup";
 		private static string FILE_TYPE_NODES(FileType fType)
 		{
 			switch(fType)
@@ -227,7 +229,13 @@ namespace Studio_One_File_Finder
 			else
 			{
 				//File.Delete(sourceFilePath);
-				File.Move(sourceFilePath, sourceFilePath + "oldbackup");
+				string newBackupPath = sourceFilePath + BACKUP_FILE_EXTENSION;
+				if (File.Exists(newBackupPath))
+				{
+					File.Delete(newBackupPath);
+				}
+
+				File.Move(sourceFilePath, newBackupPath);
 				File.Move(tempFilePath, sourceFilePath);
 				_projectsUpdated++;
 			}
@@ -294,33 +302,40 @@ namespace Studio_One_File_Finder
 		/// <param name="elements"></param>
 		void UpdateXmlNodes(XmlNodeList elements)
 		{
-			foreach (XmlNode element in elements)
+			string? currentFilePath = null;
+			void UpdateXmlNode(XmlNode element, bool modifiedFileName=false)
 			{
-				string? fpath = element.Attributes?.GetNamedItem("url")?.Value;
-				if (fpath == null) continue;
-				string fileName = GetFileName(fpath);
-				string[] fileDir = fpath.Split("file:///");
-				if (File.Exists(fileDir[fileDir.Length - 1]))
+				if (!modifiedFileName)
 				{
-					if (!_userConfig.OverwriteValidPaths)
+					currentFilePath = element.Attributes?.GetNamedItem("url")?.Value;
+					if (currentFilePath == null) return;
+				}
+				string fileName = GetFileName(currentFilePath);
+				if (!modifiedFileName)
+				{
+					string[] fileDir = currentFilePath.Split("file:///");
+					if (File.Exists(fileDir[fileDir.Length - 1]))
 					{
-						_currentOutput($"{fileName} already exists with the current path. Not overwriting.");
-						continue;
-					}
-					else
-					{
-						_currentOutput($"{fileName} already exists with the current settings, but we are going to overwrite it if we can.");
+						if (!_userConfig.OverwriteValidPaths)
+						{
+							_currentOutput($"{fileName} already exists with the current path. Not overwriting.");
+							return;
+						}
+						else
+						{
+							_currentOutput($"{fileName} already exists with the current settings, but we are going to overwrite it if we can.");
+						}
 					}
 				}
-				var matchingFile = SearchForFile(fpath);
+				var matchingFile = SearchForFile(currentFilePath);
 				if (matchingFile != null)
 				{
 					string newAttrib = "file:///" + matchingFile.Replace("\\", "/");
-					if (fpath == newAttrib)
+					if (currentFilePath == newAttrib)
 					{
 						// No need to overwrite, the link is already good
 						_currentOutput($"{fileName} was already linked correctly");
-						continue;
+						return;
 					}
 					_currentOutput($"FOUND A MATCH!!! {fileName} found in {matchingFile}");
 					// rewrite
@@ -329,10 +344,33 @@ namespace Studio_One_File_Finder
 				}
 				else
 				{
-					_currentOutput($"Couldn't find a match for {fileName} ...");
+					if (_userConfig.UpdateDuplicateFiles && FilenameAppearsToBeDuplicated(fileName) && !modifiedFileName)
+					{
+						currentFilePath = RemoveDuplicateFileRegex(currentFilePath);
+						_currentOutput($"{fileName} appears to be a duplicate file. Checking for {GetFileName(currentFilePath)} instead...");
+						UpdateXmlNode(element, true);
+					}
+					else
+					{
+						_currentOutput($"Couldn't find a match for {fileName} ...");
+					}
 				}
 			}
+			foreach (XmlNode element in elements) // TODO a lot of this could maybe be refactored? we might have to call this method again on files we're searching that we modify
+			{
+				UpdateXmlNode(element);
+			}
 
+		}
+		string DUPE_PATTERN = @"\([0-9]+\)\.[^.]*$";
+		string DUPE_PATTERN_REPLACE = @"\([0-9]+\)(?=\.[^.]*$)";
+		private bool FilenameAppearsToBeDuplicated(string fName)
+		{
+			return Regex.IsMatch(fName, DUPE_PATTERN);
+		}
+		private string RemoveDuplicateFileRegex(string filePath)
+		{
+			return Regex.Replace(filePath, DUPE_PATTERN_REPLACE, "");
 		}
 		/// <summary>
 		/// I hate this. I want to copy s1's format EXACTLY (or as close as possible). This probably doesn't matter a single bit

--- a/Studio One File Finder/MainPage.xaml
+++ b/Studio One File Finder/MainPage.xaml
@@ -168,7 +168,7 @@
                         <VerticalStackLayout>
                             <HorizontalStackLayout ToolTipProperties.Text="If a file ends with a number in parentheses, we will try to replace it if it's invalid.">
                                 <CheckBox x:Name="DupeFilesCheckBox"
-                                  IsChecked="False" />
+                                  IsChecked="{Binding UpdateDuplicates, Mode=TwoWay}" />
                                 <Label Text="Assume Duplicate Files" VerticalTextAlignment="Center"/>
                             </HorizontalStackLayout>
                             <HorizontalStackLayout ToolTipProperties.Text="Even if a file's current path is valid, change it to one in the sample directories if found. Not recommended!">


### PR DESCRIPTION
Samples can now be replaced with valid files under a similar name but without the (number) before the file extension.