### PR TITLE
Samples with an expected audio extension are cached beforehand, if th…

### DIFF
--- a/Studio One File Finder/FilePreferencesViewModel.cs
+++ b/Studio One File Finder/FilePreferencesViewModel.cs
@@ -258,6 +258,11 @@ namespace Studio_One_File_Finder
 			};
 			FileUpdater.Callback outputHandler = (string message) =>
 			{
+				if (message == "")
+				{
+					OutputText += "\n";
+					return;
+				}
 				DateTime curDate = DateTime.Now;
 				string msgToOut = $"\n<{curDate.ToString("HH:mm:ss.fff")}> {message}";
 				OutputText += msgToOut;


### PR DESCRIPTION
…ey aren't found in our dict we know they aren't there. If it has an unknown extension we'll search our whole sample folders